### PR TITLE
The stivale repsitory has been renamed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,7 +18,7 @@ dependencies = [
 [[package]]
 name = "stivale"
 version = "0.2.1"
-source = "git+https://github.com/Andy-Python-Programmer/stivale-rs#96dde15efe2519a9a3c02d8ab4c0fb694e74a3ef"
+source = "git+https://github.com/Andy-Python-Programmer/stivale#62b05bb7a1924001f647cfaa5893efa4f12d2e5b"
 dependencies = [
  "bitflags",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-stivale = { git = "https://github.com/Andy-Python-Programmer/stivale-rs" }
+stivale = { git="https://github.com/Andy-Python-Programmer/stivale" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,6 @@
 #![feature(llvm_asm)]
 
 use core::panic::PanicInfo;
-use core::ptr;
 use stivale::{HeaderFramebufferTag, StivaleHeader};
 
 static STACK: [u8; 4096] = [0; 4096];


### PR DESCRIPTION
* The stivale repository has been renamed from
https://github.com/Andy-Python-Programmer/stivale-rs to https://github.com/Andy-Python-Programmer/stivale
* Remove unused use in main.rs

Fixes: #1 

Signed By: Anhad Singh