### PR TITLE
Switch to using the published version of stivale-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,13 +12,14 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 name = "rust_limine_barebones"
 version = "0.1.0"
 dependencies = [
- "stivale",
+ "stivale-boot",
 ]
 
 [[package]]
-name = "stivale"
+name = "stivale-boot"
 version = "0.2.1"
-source = "git+https://github.com/Andy-Python-Programmer/stivale#62b05bb7a1924001f647cfaa5893efa4f12d2e5b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6338b6417a0e109faec315306ff0076bcfc5f239e099043c6ee734332a804d3"
 dependencies = [
  "bitflags",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-stivale = { git="https://github.com/Andy-Python-Programmer/stivale" }
+stivale-boot = "0.2.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,17 +3,19 @@
 #![feature(llvm_asm)]
 
 use core::panic::PanicInfo;
-use stivale::{HeaderFramebufferTag, StivaleHeader};
+use stivale_boot::v2::{StivaleFramebufferHeaderTag, StivaleHeader};
 
 static STACK: [u8; 4096] = [0; 4096];
 
-static FRAMEBUFFER_TAG: HeaderFramebufferTag = HeaderFramebufferTag::new().bpp(24);
+static FRAMEBUFFER_TAG: StivaleFramebufferHeaderTag =
+    StivaleFramebufferHeaderTag::new().framebuffer_bpp(24);
 
 #[link_section = ".stivale2hdr"]
 #[no_mangle]
 #[used]
-static STIVALE_HDR: StivaleHeader = StivaleHeader::new(&STACK[4095] as *const u8)
-    .tags((&FRAMEBUFFER_TAG as *const HeaderFramebufferTag).cast());
+static STIVALE_HDR: StivaleHeader = StivaleHeader::new()
+    .stack(&STACK[4095] as *const u8)
+    .tags((&FRAMEBUFFER_TAG as *const StivaleFramebufferHeaderTag).cast());
 
 #[no_mangle]
 extern "C" fn entry_point(_header_addr: usize) -> ! {


### PR DESCRIPTION
* Switch to using the crates.io version of stivale-rs
(https://github.com/Andy-Python-Programmer/stivale). The crate has been
published as `stivale-boot`
* The crate has been fully rewritten and now supports all of the
structures in the stivale specification so, also includes changes to
that

Signed By: Anhad Singh